### PR TITLE
Attempt to close sockets after use.

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -51,7 +51,13 @@ class Results(MutableMapping, MutableSequence):
         return wait_for
 
     def _make_request(self):
-        return self.api._request_session.get(url=self.url, params=self.kwargs, verify=self.api.verify_ssl)
+        rv = self.api._request_session.get(url=self.url, params=self.kwargs,
+                                           verify=self.api.verify_ssl)
+        try:
+            rv.connection.close()
+        except AttributeError:
+            pass
+        return rv
 
     def _get_results(self):
         if not hasattr(self.api, '_request_session'):

--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -51,18 +51,10 @@ class Results(MutableMapping, MutableSequence):
         return wait_for
 
     def _make_request(self):
-        rv = self.api._request_session.get(url=self.url, params=self.kwargs,
-                                           verify=self.api.verify_ssl)
-        try:
-            rv.connection.close()
-        except AttributeError:
-            pass
-        return rv
+        with Session() as session:
+            return session.get(url=self.url, params=self.kwargs, verify=self.api.verify_ssl)
 
     def _get_results(self):
-        if not hasattr(self.api, '_request_session'):
-            self.api._request_session = Session()
-
         wait_for = self._wait_time()
         if self.api.rate_limit and (wait_for is None or self.product == 'account-information'):
             data = self._make_request()


### PR DESCRIPTION
There seems to be a file descriptor leak, which comes up when a long-lived script makes many requests.  Not sure this is the perfect place to fix it, but it works for my use case.