### PR TITLE
In exception, add the reason for the exception to the log message

### DIFF
--- a/domaintools/exceptions.py
+++ b/domaintools/exceptions.py
@@ -6,7 +6,7 @@ class ServiceException(Exception):
     def __init__(self, code, reason):
         self.code = code
         self.reason = reason
-        super(ServiceException, self).__init__()
+        super(ServiceException, self).__init__(str(reason))
 
 
 class BadRequestException(ServiceException):


### PR DESCRIPTION
This allows users of logging/Logger ``.exception()`` to capture the reason for the failure for ex post facto investigations.