### PR TITLE
Make 3.7 compatible, fix missing import, update to aiohttp 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = ['requests']
 packages = ['domaintools']
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
     packages.append('domaintools_async')
-    requires.append('aiohttp==2.3.6')
+    requires.append('aiohttp>=3.0.0,<4.0.0')
 elif sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     requires.extend(['ordereddict', 'argparse'])
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = ['requests']
 packages = ['domaintools']
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 5:
     packages.append('domaintools_async')
-    requires.append('aiohttp>=3.0.0,<4.0.0')
+    requires.append('aiohttp==3.4.4')
 elif sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     requires.extend(['ordereddict', 'argparse'])
 


### PR DESCRIPTION
Sorry, I had to de-genericize AIter due to having to defer actually getting the results until the first async context, namely `__anext__`.