### PR TITLE
Allow installation on python 3.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,13 @@ from setuptools.command.test import test as TestCommand
 
 requires = ['requests']
 packages = ['domaintools']
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 5 and sys.version_info[2] >= 2:
+
+major, minor, patch = sys.version_info
+
+if major >= 3 and (minor > 5 or (minor == 5 and patch >= 2)):
     packages.append('domaintools_async')
     requires.append('aiohttp==3.4.4')
-elif sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+elif major == 2 and minor <= 6:
     requires.extend(['ordereddict', 'argparse'])
 
 MYDIR = path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Fix a regression introduced in 941a85d2b7ad27f510c4109379e352bc4246cc0e which prevented the installation of domaintools-async on python 3.7.0/3.7.1.

The version check in setup.py was too strict with the use of the patch level identifier.

Some quick throwaway code used for validating the logic:

```
vers = [
    (3, 7, 0),
    (3, 7, 1),
    (3, 6, 7),
    (3, 6, 7),
    (3, 6, 3),
    (3, 6, 2),
    (3, 6, 1),
    (3, 6, 0),
    (3, 5, 3),
    (3, 5, 2),
    (3, 5, 1),
    (3, 5, 0),
    (3, 4, 1),
    (3, 4, 0),
    (2, 7, 1),
    (2, 7, 0),
    (2, 6, 7),
    (2, 6, 6),
    (2, 6, 5),
]

_requires = ['requests']
_packages = ['domaintools']

for vertup in vers:

    requires = list(_requires)
    packages = list(_packages)

    major, minor, patch = vertup

    if major >= 3 and (minor > 5 or (minor == 5 and patch >= 2)):
        packages.append('domaintools_async')
        requires.append('aiohttp==3.4.4')
    elif major == 2 and minor <= 6:
        requires.extend(['ordereddict', 'argparse'])

    print(vertup)
    print(packages, requires)
```