### PR TITLE
aiohttp for python 3.6+ & setuptools depreciation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ setup(name='domaintools_api',
         ]
       },
       packages=packages,
-      requires=[package.split('==')[0] for package in requires],
       install_requires=requires,
       cmdclass=cmdclass,
       ext_modules=ext_modules,

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,13 @@ packages = ['domaintools']
 
 major, minor, patch = sys.version_info[:3]
 
-if major >= 3 and (minor > 5 or (minor == 5 and patch >= 3)):
-    packages.append('domaintools_async')
-    requires.append('aiohttp==3.4.4')
+if major >= 3:
+    if minor == 5 and patch >= 3:
+        packages.append('domaintools_async')
+        requires.append('aiohttp==3.4.4')
+    if minor > 5:
+        packages.append('domaintools_async')
+        requires.append('aiohttp>=3.4.4,<4.0.0')
 elif major == 2 and minor <= 6:
     requires.extend(['ordereddict', 'argparse'])
 


### PR DESCRIPTION
- Allow a wider range of aiohttp versions to be installed on python3.6+
- Remove the use of `requires` from the setup keywords list.  `install_requires` is the favored keyword per https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies.  This has been deprecated https://github.com/pypa/setuptools/pull/1541

Tested in 3.7.  Would recommend testing this across all support python versions.