### PR TITLE
use post for iris investigation api

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -57,8 +57,10 @@ class Results(MutableMapping, MutableSequence):
     def _make_request(self):
         with Session() as session:
             if self.product in ['iris-investigate']:
+                post_data = self.kwargs.copy()
+                post_data.update(self.api.extra_request_params)
                 return session.post(url=self.url, verify=self.api.verify_ssl,
-                        data={**self.kwargs, **self.api.extra_request_params})
+                        data=post_data)
             else:
                 return session.get(url=self.url, params=self.kwargs, verify=self.api.verify_ssl,
                         **self.api.extra_request_params)

--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from domaintools.exceptions import (BadRequestException, InternalServerErrorException, NotAuthorizedException,
                                     NotFoundException, ServiceException, ServiceUnavailableException,
-                                    IncompleteResponseException)
+                                    IncompleteResponseException, RequestUriTooLongException)
 from requests import Session
 
 try: # pragma: no cover
@@ -56,8 +56,12 @@ class Results(MutableMapping, MutableSequence):
 
     def _make_request(self):
         with Session() as session:
-            return session.get(url=self.url, params=self.kwargs, verify=self.api.verify_ssl,
-                               **self.api.extra_request_params)
+            if self.product in ['iris-investigate']:
+                return session.post(url=self.url, verify=self.api.verify_ssl,
+                        data={**self.kwargs, **self.api.extra_request_params})
+            else:
+                return session.get(url=self.url, params=self.kwargs, verify=self.api.verify_ssl,
+                        **self.api.extra_request_params)
 
     def _get_results(self):
         wait_for = self._wait_time()
@@ -124,7 +128,9 @@ class Results(MutableMapping, MutableSequence):
         elif code == 503: # pragma: no cover
             raise ServiceUnavailableException(code, reason)
         elif code == 206: # pragma: no cover
-            return IncompleteResponseException(code, reason)
+            raise IncompleteResponseException(code, reason)
+        elif code == 414: # pragma: no cover
+            raise RequestUriTooLongException(code, reason)
         else: # pragma: no cover
             raise ServiceException(code, 'Unknown Exception')
 

--- a/domaintools/exceptions.py
+++ b/domaintools/exceptions.py
@@ -31,3 +31,6 @@ class ServiceUnavailableException(ServiceException):
 
 class IncompleteResponseException(ServiceException):
     pass
+
+class RequestUriTooLongException(ServiceException):
+    pass

--- a/tests/fixtures/vcr/test_iris_investigate.yaml
+++ b/tests/fixtures/vcr/test_iris_investigate.yaml
@@ -2,51 +2,109 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.19.1]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.20.0
     method: GET
-    uri: https://api.domaintools.com/v1/iris-investigate/?domain=amazon.com%2Cgoogle.com
+    uri: https://api.domaintools.com/v1/account
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+1YbW/rxBL+K5E/XqU++77eSJWAgrhIPYDuOcAHWlkbe5Msx7Et2zltOer97cw6
-        TbN27LSUgABVqtTYnpl9ZmZ3dub5FFSmLou8NsHsU5DZtW1ic5sYk5o0mC10VptpsNJ1vC4qE4Ps
-        Jmvqxw9rU9d6CarBV/kvxd3krthUk1Q3OgymwYNwnBSbvAlmZBo0RaOz3TN6lAhmP38K0mKtbQ6W
-        9Fr/WuRhUqzBxs2qsHW8qTL4sGqasp5dvbl6074NtxpNUWS1k75609HUaW0evPqos43DCG93a9+D
-        QGZudTCL4FfS2I8g0FQb8GlZFMvMxDrX2V1jk/qIhXRtc3Anb8CCE8v1urPgf4u6Weu6MdV08nkL
-        bnJpljqbfGnKJuwaK6qlr/og/t4kq7zIiqU19XTyTZ70tOqmMqbxFb8PvwsnXxS3kwgjshemRGAF
-        Colt7nzx/5m82EthQrgUrV3ddFz59se9FKccRxKkSvBPZ75YpDiS3qpMsHZV91h1Fv7hXdeTclXk
-        nRUxQYIIwZBgnkGuhDO40LcDshJh5LuMcQSyBrZJ1u6xnfjqMS+fdfbMTlFIzu6vQXVus8zmy2M5
-        PprFp5LV/d7PTV+7l5Je/A5y0TN+mIInEtD93It49+MuxC5mlVla8FTnzevR+PcdDcmkao9G48Jv
-        k7aev2b5X5Zlyh+ynFQG4hCnvWBgpdgZRmcU9+rAbWkr3dgiP1AhiJBWBQ2Ujnh3+3sYh4ARhohg
-        kJ+92FpXH9ZFbpui6spiiAcW8v4aklno+HcHAbWadfaoee1u/NQ672DXbzuTQ6t6vqkNGCoz15zU
-        n43jQyySMnKr2LI1AdahI+o0HFiKkJIQIxoSxH1l13/UnYhhwZF6lFBKSU5a8w+bDw5q2knJpvYi
-        yylSilAOdm1dDpzEL6Gtm7wz1UebmHryTWUynaeTyyb1jMDFGbF7l55xX1QUYiH2SoL981yBXISE
-        45CwNjdeXgT/q71xu6pXGBmWTDEyip6GkoUCA3Tmn5dD5AQphryYUBnJUwD/AAfOdmp73wNFBFLy
-        3i22vm0huePqG9me2bN63ZTh0PnFbeHdFZan6oqrkw/HcJ9kGWIJUYqiUPkl3YEqK1tU7VXC3aO7
-        +OIadpSpBsHmNQ5LisP0LjdJE+ZwZe1vExUNAh2SpQxxLoawRqGEPxT6JZlDBK/dJjiEQ47A4SeA
-        w0IMJYv38bAxPHQUDxPkZOHBHThwN4/BYeNwGD1deHp42AieMnX7B0blSsOv7hpYkIgOb6BhBUoJ
-        ooPbnbmygCFUHiaMkRBoHJbYw0qKcPPBP3/gPBoE1pOUgpGozfIIJMx9SAqqmwvU9c50XNn6g7Pv
-        /sd1UlSmpRfcLQw9Vf7AMGyb0+BmZRuTwYjiKApf4X47vaS2MsmRKW0nER/61Rd8HIT+SF/smXlZ
-        i7wzUPm6b6EtebttS47qxK4R3rgABklmIZY/lK6z+74qVnYOgUwD1yWVi9jmiwLswk8Soqs3ZaUn
-        Nk+yTWpm8A57Jdp/T4beb1/VpqV1Jmc6yyYfz52RE1oMtr3dFrUr2Lpe+fFBRszTRBsuIkMFpolI
-        saSJmmNMEmiPFwtoxOXcGzAIaueRzfyX3va5+Pb85ubGgzX97nx/dV9dbeM/vTx/B712k5npu/fn
-        PwEcmy+bIp9enPcnBdgGOre/tn32cD/QTylhlPqTQHt4mixtz2LLs5l5DdmM92QguAPnCxqleNNm
-        PI0buzawG9ZlezJxdIbkGUHvMYZ+Y8ZJKCijnAauUjySeVsy7SVkXkfzuWQe/hPJvKPT6tftOpPL
-        ywuvAHIpT8/6XHzuVUKKkWTkZezPk/PnC/mfV87sz+LMXnfg86L5LGrqNZjPC+Y4AyTPkDrDHikB
-        7Rp5kgRCrRYdWHCIBPq97M7fgLIhWIQ8CgmWIfVoDiLVADPAsdgzA5xh6JjxsQE7z7xGXkVIwKB8
-        OF8PbV8ipSB4nNHYo2YeatVOO38D1Ed4gKyBXrAu17dhFna6ht14gRlmERucRKDLCYnH13LJ1dAc
-        osKIh31hmN8YirpsAMgGzyUEhsBiqsTwgDkorSSlA3ghmYSqLXPoz3KK8HFCYBhOxPDJ4LAeHMlG
-        JkvHBwwtIIQaJgNegkZ00MCUK8bZgEEwVJ0uNFEXDMX0nz3hPneGHbxpiYj+6rm1N2DG8OQlffL/
-        Z4yMi4gpbBKUJoJpjFFizJyKuU4XZo64iSTnEuqQT67I0YnxP97qMC/uwwRz4lunDYmZ/GjNjZsW
-        L3RmF0WVW92bFplqucWxgXEo+FCfBe72AIeugospJTACK5YwQ2VKkySdk4grRLlQKY1kwhn3LhJ8
-        dDY+ha/QEPxxX084FpMZojNCQseBK9ZeCmtb12402p6rul3x/jegExNRgiMAAA==
+        H4sIAAAAAAAAA5WQ0WrDMAxF/0XPKcQdY9BfKSN4idYIHNlIctkI+ffZaTvysI5WT5bule7BMwhq
+        iqwIhxl838fMtj4TdVlR2E9FgkA6IkNTLEbnMjHJuDSQJA65N4XDcQYaivN6Y0f8GWXyRrGuJZRu
+        imxjF2iikgCurXWTiLPhr/Zagz40hs2QcwgNZPWnFdXi4L+rtXrXy6V520Nhwq9EsgZ3gze8rC7N
+        lY+EdIcs1I9Pc7l9+zhZuwF7eZCL+IxqdKryPbi/0Z4hc26D5v75s/dl+QHu24RXIQIAAA==
     headers:
-      content-encoding: [gzip]
-      content-type: [application/json;charset=utf-8]
-      date: ['Fri, 20 Jul 2018 22:32:29 GMT']
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 18 Dec 2019 07:32:41 GMT
+      Server:
+      - Chuck Norris fears nothing that is not Emily.
+      Vary:
+      - Accept-Encoding
+      X-TIME:
+      - '87996'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: domain=amazon.com%2Cgoogle.com
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.20.0
+    method: POST
+    uri: https://api.domaintools.com/v1/iris-investigate/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZbW/byBH+K4I+FjKz7y8GDCT1FW1QJz4k6fVDHRArciXzQpEsScV2At9v7yxp
+        WUuKVGyfrrjcGQgQezkz+8zL7s48/jotbVXkWWWnx1+nabJK6tBeR9bGNp4eL0xa2dn00lThKi9t
+        CLLrtK7uP6xsVZklqE7/lv2c30xu8nU5iU1tgulseiccRvk6q6fHZDat89qk3u/35v7zdRrnK5Nk
+        YMmszJc8C6J8BTauLvOkCtdlCh8u67qoji9eXLxoVoNWo87ztHLSFy86miau7J1Xn026dhhh9W5v
+        dAsCqb0202MMOExUJ59Boi7X4NQyz5epDU1m0ps6iao9JuJVkoE/WQ0WnFhmVp0d/5FX9cpUtS1n
+        k1cNusmZXZp08oMt6q0tShBlYC8vl772ncYHG11meZovE1vNJq+zaKvIpFAaFKu6tLb2dX8MzoPJ
+        X/PricKI+DthTEAhSuobX/ydzfKtFEZIEtTYNXXHobc/baUE4ohzkCrAS5P6YkpzJL1dKWpgNr+W
+        nY3XlbetYkJypaWzeZlnnZ0xQYIIwZBgnmGGG+mFuR6QlQgjHwRBCmQtVE3alNxG/PI+Sy87JbRR
+        5JiS24+gOk/SNMmW+zLeLZBeQrsfd5PW/d7PUV+7l5ru592c9IzvpqJnoJ+A7udexLsfNyF2MSvt
+        MgFPTVY/H5Q/+kGBEKrmoNQuE0nUXPbPOf9D55xRhpqcR6WFeIRxLyhYa3aE8RHCni/aRcZeF0lp
+        6iTPdpQIIqCEjqinJDXhG4ThplvwgA6iI5woDY5txVam/LTKs6TOy64spoJwzm4/QmZzE+5Goszz
+        ejAGkgAyp1al92ofXXcQJ847OAVtG7Nr0szXlQVbReo6merlODiMuebUd6SxWdr/rm1VjytKpjFu
+        nEqKZmtABW1Xp6nBUgSUBBjRgCDubeqqx1SdMGPBkd5KMCqlRsLZv6tfOPGxHStiihUiApILhpOq
+        GDjPP0DzOHlvy89JZKvJ69KmJosnZ3Xsw0KE0lsXi3FntAqwEL4S+w6dgXQEhOOAsCY9nhoR/3d3
+        XGG5GzbwrljFCYIt3B6r6waLuy983fbAHFWrugiGDg8Wrso253n/cSbuKG8KeRsjGWCJA6xUwPxr
+        GvunxZcCyP7J4r4ch9JhASYskL6tvgzGOiCYBpipziEd2xJi65sT43Kkaw8CW5RJXjZPUnPLuGc0
+        rKCobDkY8KzCQUFxEN9kNqqDzHpvKSeMDUZ7SJgyIhUZCrgKJPxDgX89g2nq3oEhQGQPII4OAAgy
+        BncX30GkxxDRUURMqkMgakOEO4Aa0yOA2B5ARB0uRH1EZCRERezqCKbz0sBP3U2wwILoQUzDClRD
+        XcthVBKAQbT87gDOh7u2xmCJLawoD9af/Ce8eeyGgPUkudZQHngcEuY+JA33rRsBP25Mh2VSfXL2
+        3f9hFeUlKCMnvyqgN8vuSI225YWnOqltCmOQY0V8hdt2QoqT0kZ7JsGNRLjrV1/wfth6areNJNZd
+        S49vvDWV1LNR+upvXr3755vzt68/nL8DtbenwcxbcQte70KpUtg3FLqee+1iO43SBMIc29TWtijz
+        y2QOMY4n7bIDXi1sufNhXbhW01tuL9IdM+3ygJn2Q9/M1HV/xSJMskUOPsKPJEAXL4rSTJIsStex
+        PYY17D2A/joZWm+XKttwW5Mjk6aTzyfOyAEtTtuetUXtnhJTXXYOTbSQJqZMLSRfKDqneMEWMcV8
+        zrhaQKUYK0DGe3W1y3u1nv/cq+fTtyd/CQq7DAz54rafnZ9sm4qLi6aAgtnZyXuYIerUzt5/OPk3
+        gEmyZZ1ns9OTf733ugBO2nHQZMmXZn4Y7lVmvWZFUyVFl53YdRlZMY8jY7lQlgpMIxFjSSM9h9Ew
+        olwuFlwLOe+80mrU56urKy8Tv8ZpaDQO5DSUap3GzZXYMKx2XkEJh1saGNojuOagdQ3bMo/DOlnB
+        kGFWRXvh1GZZbeJ3T9u2rOlTaNuO5oNp29+Qtd3L4f292WdyduZdVIoqdnhC7/RVp2UklDP9NGbv
+        wTzCEzm+Z170t+JFn0vxkWF9EPP4HNVHRnWc25NHSB9hnzTSTaj2k3uq0fK5Ssnu9xwi9zpvxD3t
+        hrRg5DDkHkwTR83D8HJoK0JhI/o9c3wEi4DDmKUpDKbeHMSHaDGOhc8jEYkE5wfgkYaOFna8NaR/
+        lAJrgRMsA+rzeez3A3wP+ZXW0KJXxeo6SIOhwsJccSobMm93thtUgKpXRN0P0x1+yP1ZYhAE+QYI
+        yTiiwzzco0HQMRB0LwgBI7kUw8P7ozGwMQzsGxjAJjpQHPgwhn15EJQJ5W60Q+yP0UPZwkHTVOGH
+        A4GRYZB1grNLqG7/uNCZmLAc5wqH4Qj28EPyLTisB4eLEbrJEYWDhaLo4dCIDhp4u/E4SThctWyY
+        sXwKGNUFwwT9vmmvUcGHdH1I/KlprB7fFMJvXgFOfnkAg6QFVZQKFDMxVyzSlAjoVhhbECJjJSNK
+        saGcG+8V5nsYpO3us/OTbcpmZydvnDYUyeSnxF45JuXUpMkiL7PE9JgUjfQ+KmXwqUdCaP0t6ohL
+        oyVhmiIk54uF0WSBBZvjiBpkJOcLhGIciblndy9xdAhnqWp6i1/p7AEpI9crJVXl2IL2VLfLt/8D
+        emXqMYgoAAA=
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 18 Dec 2019 07:32:41 GMT
+      Server:
+      - Chuck Norris fears nothing that is not Emily.
+      Vary:
+      - Accept-Encoding
+      X-TIME:
+      - '296905'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,7 @@ def remove_server(response):
     return response
 
 
-vcr = VCR(before_record_response=remove_server, filter_query_parameters=['timestamp', 'signature', 'api_username'],
+vcr = VCR(before_record_response=remove_server, filter_query_parameters=['timestamp', 'signature', 'api_username'], filter_post_data_parameters=['timestamp', 'signature', 'api_username'],
           cassette_library_dir='tests/fixtures/vcr/', path_transformer=VCR.ensure_suffix('.yaml'),
           record_mode='new_episodes')
 with vcr.use_cassette('init_user_account'):


### PR DESCRIPTION
Currently iris_investigate api may fail for "414 uri too large error" due the size limit of GET method.  

- Changed GET to POST to support investigating up to 100 domains in an API call.

- Add an exception to notify error code 414.