### PR TITLE
Updated to >=3.6.0 aiohttp to clear deprecation warning.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if major >= 3:
         requires.append('aiohttp==3.4.4')
     if minor > 5:
         packages.append('domaintools_async')
-        requires.append('aiohttp>=3.4.4,<4.0.0')
+        requires.append('aiohttp>=3.6.0,<4.0.0')
 elif major == 2 and minor <= 6:
     requires.extend(['ordereddict', 'argparse'])
 


### PR DESCRIPTION
Quick fix to remove this error:

`/usr/local/lib/python3.7/site-packages/aiohttp/multipart.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Mapping, Sequence, deque`

Just need to kick aiohttp up above 3.6.0 for users of Python 3.5 and up. 