### PR TITLE
Logical bug fix

### DIFF
--- a/domaintools/api.py
+++ b/domaintools/api.py
@@ -12,7 +12,7 @@ AVAILABLE_KEY_SIGN_HASHES = ['sha1', 'sha256', 'md5']
 
 def delimited(items, character='|'):
     """Returns a character delimited version of the provided list as a Python string"""
-    return '|'.join(items) if type(items) in (list, tuple, set) else items
+    return character.join(items) if type(items) in (list, tuple, set) else items
 
 
 class API(object):


### PR DESCRIPTION
`domain_search` API expects space-separated `exclude_query` terms and not `|` separated. This diff aims to fix the fundamental issue in `delimited` function.
https://www.domaintools.com/resources/api-documentation/domain-search/