### PR TITLE
Catch response limit

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -33,6 +33,7 @@ class Results(MutableMapping, MutableSequence):
         self._items_list = None
         self._data = None
         self._limit_exceeded = None
+        self._limit_exceeded_message = None
 
     def _wait_time(self):
         if not self.api.rate_limit or not self.product in self.api.limits:

--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -94,7 +94,7 @@ class Results(MutableMapping, MutableSequence):
                 self._data = results.json()
             else:
                 self._data = results.text
-            limit_exceeded, message = self.test_limit_exceeded()
+            limit_exceeded, message = self.check_limit_exceeded()
 
             if limit_exceeded:
                 self._limit_exceeded = True
@@ -105,7 +105,7 @@ class Results(MutableMapping, MutableSequence):
         else:
             return self._data
 
-    def test_limit_exceeded(self):
+    def check_limit_exceeded(self):
         if self.kwargs.get('format', 'json') == 'json':
             if ("response" in self._data and
                 "limit_exceeded" in self._data['response'] and

--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -101,7 +101,7 @@ class Results(MutableMapping, MutableSequence):
                 self._limit_exceeded_message = message
 
         if self._limit_exceeded is True:
-            raise ServiceException(503, f"Limit Exceeded {self._limit_exceeded_message}")
+            raise ServiceException(503, "Limit Exceeded{}".format(self._limit_exceeded_message))
         else:
             return self._data
 

--- a/domaintools_async/__init__.py
+++ b/domaintools_async/__init__.py
@@ -4,7 +4,7 @@ import aiohttp
 
 from domaintools.base_results import Results
 
-from domaintools.exceptions import ServiceUnavailableException
+from domaintools.exceptions import ServiceUnavailableException, ServiceException
 
 class _AIter(object):
     """A wrapper to wrap an AsyncResults as an async iterable"""
@@ -41,6 +41,11 @@ class AsyncResults(Results):
                 self._data = await results.json()
             else:
                 self._data = await results.text()
+            limit_exceeded, message = self.test_limit_exceeded()
+
+            if limit_exceeded:
+                self._limit_exceeded = True
+                self._limit_exceeded_message = message
 
     async def __awaitable__(self):
         if self._data is None:

--- a/domaintools_async/__init__.py
+++ b/domaintools_async/__init__.py
@@ -41,7 +41,7 @@ class AsyncResults(Results):
                 self._data = await results.json()
             else:
                 self._data = await results.text()
-            limit_exceeded, message = self.test_limit_exceeded()
+            limit_exceeded, message = self.check_limit_exceeded()
 
             if limit_exceeded:
                 self._limit_exceeded = True

--- a/tests/fixtures/vcr/test_limit_exceeded.yaml
+++ b/tests/fixtures/vcr/test_limit_exceeded.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: !!python/unicode 'api_key=fde3b-8cfc3-2e1b7-58eca-a1156&ip=8.8.8.8'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.domaintools.com/v1/iris-investigate/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMQQ7CMAwEv2L5DKgXLv0DL0AoishSLNUJ2InUqurfGw5cZ3dmY4N/SnbwuPEs
+        KjVgeQIJicdqDSd+Rw9aDKFf21z9zxXuceoi3+Ii2pSuwzCQoTbLSHSmtTTSuFLuPaqlTy/J+GGj
+        b4OtF+4ZcZc8hVQ0Su71+2PfDzk/D2uYAAAA
+    headers:
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=utf-8
+      date:
+      - Wed, 29 Apr 2020 21:09:30 GMT
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-time:
+      - '794364'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -394,6 +394,7 @@ def test_iris():
             assert 'domain' in result
             assert str(result['domain'])
 
+
 @vcr.use_cassette
 def test_risk():
     with api.risk(domain='google.com') as result:
@@ -432,3 +433,10 @@ def test_iris_investigate():
     assert investigation_results['results_count']
     for result in investigation_results:
         assert result['domain'] == 'amazon.com' or result['domain'] == 'google.com'
+
+
+@vcr.use_cassette
+def test_limit_exceeded():
+    with pytest.raises(exceptions.ServiceException):
+        response = api.iris_investigate(ip="8.8.8.8")
+        response.response()


### PR DESCRIPTION
fixes #45 . 

In some cases, the DomainTools API does not respond with a 503 if the user has exceeded their search limits (eg > 5,000 entries in a result)...instead it returns json that says the user's limit has been exceeded. That case has to be caught in the result, so that the result object doesn't try to read results (there aren't any). This makes the result object raise a 503 exception in that case, since that seems to be the preferred way of signalling exceeded limits elsewhere in the API.