### PR TITLE
Fix issue with using proxies

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -58,6 +58,7 @@ class Results(MutableMapping, MutableSequence):
 
     def _make_request(self):
         with Session() as session:
+            session.proxies = self.api.extra_request_params['proxies']
             if self.product in ['iris-investigate']:
                 post_data = self.kwargs.copy()
                 post_data.update(self.api.extra_request_params)


### PR DESCRIPTION
The proxies are captured in the API object construction at https://github.com/DomainTools/python_api/blob/master/domaintools/api.py#L52 

But they are not used in the HTTP calls made to api.domaintools.com. This commit fixes this bug.