### PR TITLE
fix KeyError is latest commit

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -58,7 +58,7 @@ class Results(MutableMapping, MutableSequence):
 
     def _make_request(self):
         with Session() as session:
-            session.proxies = self.api.extra_request_params['proxies']
+            session.proxies = self.api.extra_request_params.get('proxies', None)
             if self.product in ['iris-investigate']:
                 post_data = self.kwargs.copy()
                 post_data.update(self.api.extra_request_params)


### PR DESCRIPTION
The last commit was failing some tests due to a KeyError. This fixes
that problem by using .get() and providing a default.