### PR TITLE
Fix spelling error that would miss limit checks on Text, XML and HTML…

### DIFF
--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -112,10 +112,9 @@ class Results(MutableMapping, MutableSequence):
                 "limit_exceeded" in self._data['response'] and
                 self._data['response']['limit_exceeded'] is True):
                 return True, self._data['response']['message']
-        else:
-            # TODO: handle html, xml response errors better.
-            if "response" in self._data and "limit_exdeeded" in self._data:
-                return True, "limit exceeded"
+        # TODO: handle html, xml response errors better.
+        elif "response" in self._data and "limit_exceeded" in self._data:
+            return True, "limit exceeded"
         return False, ""
 
     @property


### PR DESCRIPTION
… data formats.

This fixes the spelling bug but due to how the current lib is set up it would never get used unless a user changed domaintools/results.py to use the synchronous Results object.

closes ID-1267