### PR TITLE
ID-1476 Python Wrapper: Update with Ignorelist functionality

### DIFF
--- a/domaintools/api.py
+++ b/domaintools/api.py
@@ -552,3 +552,79 @@ class API(object):
         return self._results('iris-detect-escalate-domains', '/v1/iris-detect/escalations/',
                              escalation_type=escalation_type, items_path=('escalations',),
                              response_path=(), **kwargs)
+
+    def iris_detect_ignored_domains(self, monitor_id=None, escalation_types=None, tlds=None, risk_score_ranges=None,
+                                mx_exists=None, discovered_since=None, changed_since=None, escalated_since=None, search=None, sort=None,
+                                order=None, include_domain_data=False, offset=0, limit=None, preview=None, **kwargs):
+        """Returns back a list of ignored domains in Iris Detect based on the provided filters.
+
+        monitor_id: str: default None. Monitor ID from monitors response. Only used when requesting domains for a
+        specific monitor.
+
+        escalation_types: List[str]: default None. List of escalation types to filter domains by. Valid values are:
+        ["blocked", "google_safe"]
+
+        tlds: List[str]: default None. List of TLDs to filter domains by.
+
+        risk_score_ranges: List[str]: default None. List of risk score ranges to filter domains by. Valid values are:
+        ["0-0", "1-39", "40-69", "70-99", "100-100"]
+
+        mx_exists: bool: default None. Filter domains by if they have an MX record in DNS.
+
+        discovered_since: ISO 8601 datetime format: default None. Filter domains by when they were discovered.
+        Most relevant for iris_detect_new_domains endpoint to control the timeframe for when a new domain was discovered.
+
+        changed_since: ISO 8601 datetime format: default None. Filter domains by when they were last changed.
+        Most relevant for the iris_detect_watched_domains endpoint to control the timeframe for changes to DNS or whois
+        fields for watched domains.
+
+        escalated_since: ISO 8601 datetime format: default None. Filter domains by when they were last escalated.
+        Most relevant for the iris_detect_watched_domains endpoint to control the timeframe for when a domain was most
+        recently escalated.
+
+        search: str: default None. A "contains" search for any portion of a domain name.
+
+        sort: List[str]: default None. Sort order for domain list. Valid values are an ordered list of the following:
+        ["domain_discovered", "domain_changed", "risk_score"]
+
+        order: str: default None. Sort order "asc" or "desc"
+
+        include_domain_data: bool: default False. Includes DNS and whois data in the response.
+
+        offset: int: default 0. Offset for pagination
+
+        limit: int: default 100. Limit for pagination. Restricted to maximum 50 if include_domain_data is set to True.
+
+        preview: bool: default None. Preview mode used for testing. If set to True, only the first 10 results are
+        returned but not limited by hourly restrictions.
+        """
+        if discovered_since:
+            if isinstance(discovered_since, datetime):
+                kwargs["discovered_since"] = str(discovered_since.astimezone())
+            elif isinstance(discovered_since, str):
+                kwargs["discovered_since"] = discovered_since
+        if changed_since:
+            if isinstance(changed_since, datetime):
+                kwargs["changed_since"] = str(changed_since.astimezone())
+            elif isinstance(changed_since, str):
+                kwargs["changed_since"] = changed_since
+        if escalated_since:
+            if isinstance(escalated_since, datetime):
+                kwargs["escalated_since"] = str(escalated_since.astimezone())
+            elif isinstance(escalated_since, str):
+                kwargs["escalated_since"] = escalated_since
+        if escalation_types:
+            kwargs["escalation_types[]"] = escalation_types
+        if tlds:
+            kwargs["tlds[]"] = tlds
+        if risk_score_ranges:
+            kwargs["risk_score_ranges[]"] = risk_score_ranges
+        if sort:
+            kwargs["sort[]"] = sort
+        if order is not None:
+            kwargs["order"] = order
+        if mx_exists is not None:
+            kwargs["mx_exists"] = mx_exists
+        return self._results('iris-detect-ignored-domains', '/v1/iris-detect/domains/ignored/', monitor_id=monitor_id,
+                             search=search, include_domain_data=include_domain_data, preview=preview, offset=offset,
+                             limit=limit, items_path=('watchlist_domains',), response_path=(), **kwargs)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,6 +1,6 @@
 from domaintools import API
 
 
-dt_api = API('wagena-api-test-user', 'eee30-51701-98ecb-89002-69d16')
-result = dt_api.iris_investigate(domains='int-chase.com').data()
+dt_api = API(USER_NAME, KEY)
+result = dt_api.iris_enrich('google.com').data()
 print(result)

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,6 +1,6 @@
 from domaintools import API
 
 
-dt_api = API(USER_NAME, KEY)
-result = dt_api.iris_enrich('google.com').data()
+dt_api = API('wagena-api-test-user', 'eee30-51701-98ecb-89002-69d16')
+result = dt_api.iris_investigate(domains='int-chase.com').data()
 print(result)

--- a/tests/fixtures/vcr/test_iris_detect_ignored_domains.yaml
+++ b/tests/fixtures/vcr/test_iris_detect_ignored_domains.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.domaintools.com/v1/iris-detect/domains/ignored/?app_name=python_wrapper&app_version=0.6.1&include_domain_data=false&offset=0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8WUX2+bMBTFv4tflyLzxwn4qZ26l0mbomhal0wTcsCAi7EzbGjaKN9916GL2mqj
+        6RRpPFnX51xfn5/wDt0xm1VSGJvmumFCGUS/75CxzHJEkSiVbnmOJmjYhRLbMMmqhnU163LWsAet
+        vEw3IHGmzjhJZkXPnUmYTPccOqT50DDAQXCByYUffwkw9WNKiBdNY4zxO4wpxmDKKqbKvzkCn5LY
+        w4fv6GiFqVM4qQW9j/HTQnocatPqXhihFZPPLCkMv9GKKwuqnZNtRSPs/WMrW7Wc2RTKhZD8oKiE
+        qYQqEU2S/X6Cmm3KtxAg2AsmDQePzOHAIRThlst5cvWwqj/NF1DhJoMELUzisv4BDbQSVrepyF0B
+        fXxfrv3rq+ZujmCTGQMQII41TAS0Sq7Y5QDDai3NY/ZH2R9S86lPKPafp7afjFL+2QGEjOmCZXyt
+        de2O8Xr1dsr+jEZTigNvGp9I2TlmNPTHKJPobJCDccYkeoXxkMoB84rlX++TJZ7nJ2AOV9+axfXn
+        zQd9HszwL+GIhuRNmNtOWS7lU8r/gBj+ySmNYm8WJiciDmlAaETGEIdnQxyQccTha4h/8729WbTL
+        276+if4f3xeP3x56W22ZhOsDS7gM5H5c6aIwHJbwjkkXxuFN2/8CY3zCYfUFAAA=
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 18 May 2022 21:19:03 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - csrftoken=852c12424ab9230e0689956310b511c7; path=/; domain=.domaintools.com;
+        secure
+      - dtsession=s31lqpin2vge4t0qovgb78re2nrj40eviucn5oprovup5fmm892bqi8vgu5u0kmivbivf58lk5givdp72ls1lcrnqmdothnf2qaenep;
+        expires=Fri, 17-Jun-2022 21:19:03 GMT; Max-Age=2592000; path=/; domain=.domaintools.com;
+        secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.domaintools.com/v1/iris-detect/domains/ignored/?app_name=python_wrapper&app_version=0.6.1&include_domain_data=false&monitor_id=3ZXmRDNpEo&offset=0
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8WSXU/CMBSG/0tvHUv3BaNXXuitMcSIYMxSto4Vuh5cy4QQ/runEhcwisaYuKt+
+        vO85p++zHXnhNq+UNDYroOZSG8Ied8RYbgVhRM41NKIgHjnc4tHzmut5zqHkuZgBLP0car/VKHGm
+        NfoJz61shTNJk0MrsEJWHAqGNAx7NOkF6V0wYHGf0dDvpyml9IJSRima8gobfOkYsCjw6dvXORpp
+        lhl2alCfxMf7rJtp1UArjQTN1Ykjw/FXoIW2qNo52UbW0m4JC0KP2KoR3GZ4Wkol3gSVNJXUc9dp
+        v/dIvcnEBuNDd8mVEehRBfbrUpFuN+XF/XY4obcuSmFyrrjFWVzYT1gDtLTQZLJwBySaPtSjq5vV
+        NRC85MYgBcxjhjMhrrnQ/PJAwwIo4/InR7JPYksZjVmUnMa2985ibtbaCqWOKf8CccCSPotTfxAN
+        f4g4YmHC4uQc4ujPEIfJecTRd4jf+S7Go2ayaJfj+P/4ph/4Ym0Llit8PrLEx2Lu3QrK0ghcUo8o
+        Fwb+7pTuXwHotbuNDwQAAA==
+    headers:
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 18 May 2022 21:19:05 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - csrftoken=cf44264165b4357df7c3f4f94621ac34; path=/; domain=.domaintools.com;
+        secure
+      - dtsession=71ucdn1c0qh7obl2qp8rcgj41inlleoahqhh3bcusdkss70nq5e6cquplk6r9a3586pkor499lpni0v0hhuk7u9dtqela90j5r2m796;
+        expires=Fri, 17-Jun-2022 21:19:05 GMT; Max-Age=2592000; path=/; domain=.domaintools.com;
+        secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -466,6 +466,15 @@ def test_iris_detect_escalate_domains():
 
 
 @vcr.use_cassette
+def test_iris_detect_ignored_domains():
+    detect_results = api.iris_detect_ignored_domains()
+    assert detect_results['count'] == 3
+
+    detect_results = api.iris_detect_ignored_domains(monitor_id="3ZXmRDNpEo")
+    assert detect_results['count'] == 2
+
+
+@vcr.use_cassette
 def test_limit_exceeded():
     with pytest.raises(exceptions.ServiceException):
         response = api.iris_investigate(ip="8.8.8.8")


### PR DESCRIPTION
closes https://domaintools.atlassian.net/browse/ID-1467

* add `iris_detect_ignored_domains` method

I wasn't sure on a few points here:
* do we need `escalation_types`, `escalated_since` params on this endpoint? Wasn't sure if that applies to ignored domains?
* I noticed the `items_path` field has a value of "watchlist_domains" on the ignored endpoint. I left it the same way in this wrapper updated, but lmk if that should be "ignored" or something else?
* There's no "manage-ignored-domains" feature like we have for watchlist domains right?