### PR TITLE
ID-1389 Python Wrapper: Filter on counts

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,3 +136,11 @@ def test_find_ips():
                    '64.233.171.26',
                    '74.125.142.26'}
 
+def test_get_pivots():
+    pivots = utils.get_pivots(iris_investigate_data.domaintools().get("results"), "")
+    assert pivots == [
+        ['IP ADDRESS', ('199.30.228.112', 4)],
+        ['IP ASN', (17318, 111)],
+        ['IP ISP', ('DomainTools LLC', 222)]
+    ]
+


### PR DESCRIPTION
Closes https://domaintools.atlassian.net/browse/ID-1389

example:
```
response = dt_api.iris_investigate('domaintools.com').response()
pivots = utils.get_pivots(response.get('results'), "")
# [['IP ADDRESS', ('199.30.228.112', 4)], ['IP ASN', (17318, 111)], ['IP ISP', ('DomainTools LLC', 222)]]
```