### PR TITLE
[IDEV-282] Bugbash

### DIFF
--- a/domaintools/cli/api.py
+++ b/domaintools/cli/api.py
@@ -6,11 +6,13 @@ import _io
 
 from typing import Optional, Dict, Tuple
 from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich import print
+from rich import console
 
 from domaintools.api import API
 from domaintools.exceptions import ServiceException
 from domaintools.cli.utils import get_file_extension
+
+console = console.Console()
 
 
 class DTCLICommand:
@@ -73,6 +75,9 @@ class DTCLICommand:
             for i in range(0, len(args), 2):
                 key = args[i].replace("--", "")
                 value = args[i + 1].strip()
+                # replace all the "-" to "_" to make it a valid kwargs
+                # we replace all CLI parameters to use "-" instead of underscore.
+                key = key.replace("-", "_")
                 argument_dict[key] = value
         except:
             pass
@@ -193,7 +198,7 @@ class DTCLICommand:
 
                 if isinstance(out_file, _io.TextIOWrapper):
                     # use rich `print` command to prettify the ouput in sys.stdout
-                    typer.echo(output)
+                    print(output)
                 else:
                     # if it's a file then write
                     out_file.write(output if output.endswith("\n") else output + "\n")

--- a/domaintools/cli/commands/accounts.py
+++ b/domaintools/cli/commands/accounts.py
@@ -19,7 +19,7 @@ def account_information(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
@@ -36,7 +36,7 @@ def account_information(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -58,7 +58,7 @@ def available_api_calls(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(

--- a/domaintools/cli/commands/detects.py
+++ b/domaintools/cli/commands/detects.py
@@ -47,7 +47,7 @@ def iris_detect_monitors(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
@@ -64,7 +64,7 @@ def iris_detect_monitors(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -101,7 +101,7 @@ def iris_detect_new_domains(
     ),
     discovered_since: str = typer.Option(
         None,
-        "--discovered_since",
+        "--discovered-since",
         help="ISO 8601 datetime format: default None. Filter domains by when they were discovered.",
     ),
     changed_since: str = typer.Option(
@@ -145,13 +145,13 @@ def iris_detect_new_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -162,7 +162,7 @@ def iris_detect_new_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -190,7 +190,7 @@ def iris_detect_watched_domains(
     ),
     escalation_types: str = typer.Option(
         None,
-        "--escalation_types",
+        "--escalation-types",
         help="List of escalation types to filter domains by. Valid values are: {'blocked', 'google_safe'}",
     ),
     escalated_since: str = typer.Option(
@@ -212,7 +212,7 @@ def iris_detect_watched_domains(
     ),
     discovered_since: str = typer.Option(
         None,
-        "--discovered_since",
+        "--discovered-since",
         help="ISO 8601 datetime format: default None. Filter domains by when they were discovered.",
     ),
     changed_since: str = typer.Option(
@@ -256,13 +256,13 @@ def iris_detect_watched_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -273,7 +273,7 @@ def iris_detect_watched_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -304,13 +304,13 @@ def iris_detect_manage_watchlist_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -321,7 +321,7 @@ def iris_detect_manage_watchlist_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -354,13 +354,13 @@ def iris_detect_escalate_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -371,7 +371,7 @@ def iris_detect_escalate_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -399,7 +399,7 @@ def iris_detect_ignored_domains(
     ),
     escalation_types: str = typer.Option(
         None,
-        "--escalation_types",
+        "--escalation-types",
         help="List of escalation types to filter domains by. Valid values are: {'blocked', 'google_safe'}",
     ),
     escalated_since: str = typer.Option(
@@ -421,7 +421,7 @@ def iris_detect_ignored_domains(
     ),
     discovered_since: str = typer.Option(
         None,
-        "--discovered_since",
+        "--discovered-since",
         help="ISO 8601 datetime format: default None. Filter domains by when they were discovered.",
     ),
     changed_since: str = typer.Option(
@@ -465,13 +465,13 @@ def iris_detect_ignored_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -482,7 +482,7 @@ def iris_detect_ignored_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,

--- a/domaintools/cli/commands/domains.py
+++ b/domaintools/cli/commands/domains.py
@@ -25,13 +25,13 @@ def brand_monitor(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -42,7 +42,7 @@ def brand_monitor(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -65,13 +65,13 @@ def domain_profile(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -82,7 +82,7 @@ def domain_profile(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -121,13 +121,13 @@ def domain_search(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -138,7 +138,7 @@ def domain_search(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -161,13 +161,13 @@ def hosting_history(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -178,7 +178,7 @@ def hosting_history(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         True,
@@ -203,13 +203,13 @@ def name_server_monitor(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -220,7 +220,7 @@ def name_server_monitor(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -243,13 +243,13 @@ def parsed_whois(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -260,7 +260,7 @@ def parsed_whois(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -290,13 +290,13 @@ def registrant_monitor(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -307,7 +307,7 @@ def registrant_monitor(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -331,13 +331,13 @@ def reputation(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -348,7 +348,7 @@ def reputation(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -372,13 +372,13 @@ def reverse_ip(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -389,7 +389,7 @@ def reverse_ip(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -413,13 +413,13 @@ def reverse_nameserver(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -430,7 +430,7 @@ def reverse_nameserver(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -462,13 +462,13 @@ def reverse_whois(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -479,7 +479,7 @@ def reverse_whois(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -502,13 +502,13 @@ def whois(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -519,7 +519,7 @@ def whois(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -560,13 +560,13 @@ def whois_history(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -577,7 +577,7 @@ def whois_history(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -600,13 +600,13 @@ def risk(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -617,7 +617,7 @@ def risk(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -640,13 +640,13 @@ def risk_evidence(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -657,7 +657,7 @@ def risk_evidence(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,

--- a/domaintools/cli/commands/ips.py
+++ b/domaintools/cli/commands/ips.py
@@ -22,13 +22,13 @@ def ip_monitor(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -39,7 +39,7 @@ def ip_monitor(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -73,13 +73,13 @@ def ip_registrant_monitor(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -90,7 +90,7 @@ def ip_registrant_monitor(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -114,13 +114,13 @@ def host_domains(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -131,7 +131,7 @@ def host_domains(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -163,13 +163,13 @@ def reverse_ip_whois(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -180,7 +180,7 @@ def reverse_ip_whois(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,

--- a/domaintools/cli/commands/iris.py
+++ b/domaintools/cli/commands/iris.py
@@ -3,7 +3,10 @@ import typer
 
 from domaintools.cli.main import dt_cli
 from domaintools.cli.api import DTCLICommand
-from domaintools.cli.utils import get_cli_helptext_by_name
+from domaintools.cli.utils import (
+    get_cli_helptext_by_name,
+    remove_special_char_in_string,
+)
 from domaintools.cli import constants as c
 
 
@@ -68,6 +71,12 @@ def iris_investigate(
 
     extra_args = ctx.args.copy()
     kwargs = DTCLICommand.args_to_dict(*extra_args)
+    if "ssl_hash" in kwargs:
+        # silently remove the ':' if present.
+        ssl_hash_value = kwargs["ssl_hash"]
+        kwargs["ssl_hash"] = remove_special_char_in_string(
+            ssl_hash_value, special_char=":"
+        )
 
     DTCLICommand.run(name=c.IRIS_INVESTIGATE, params=ctx.params, **kwargs)
 

--- a/domaintools/cli/commands/iris.py
+++ b/domaintools/cli/commands/iris.py
@@ -39,13 +39,13 @@ def iris_investigate(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -56,7 +56,7 @@ def iris_investigate(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -90,13 +90,13 @@ def iris_enrich(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -107,7 +107,7 @@ def iris_enrich(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -139,13 +139,13 @@ def iris(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -156,7 +156,7 @@ def iris(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,

--- a/domaintools/cli/commands/iris.py
+++ b/domaintools/cli/commands/iris.py
@@ -30,8 +30,9 @@ def iris_investigate(
     ),
     src_file: str = typer.Option(
         None,
+        "-s",
         "--source-file",
-        help="Comma-separated list of domains. Supports only {.csv, .txt} format",
+        help="Comma-separated list of maximum 100 domains. Supports only {.csv, .txt} format",
         callback=DTCLICommand.validate_source_file_extension,
     ),
     user: str = typer.Option(None, "-u", "--user", help="Domaintools API Username."),
@@ -81,8 +82,9 @@ def iris_enrich(
     domains: str = typer.Option(None, "-d", "--domains", help="Domains to use."),
     src_file: str = typer.Option(
         None,
+        "-s",
         "--source-file",
-        help="Comma-separated list of domains. Supports only {.csv, .txt} format",
+        help="Comma-separated list of maximum 100 domains. Supports only {.csv, .txt} format",
         callback=DTCLICommand.validate_source_file_extension,
     ),
     user: str = typer.Option(None, "-u", "--user", help="Domaintools API Username."),

--- a/domaintools/cli/commands/phisheye.py
+++ b/domaintools/cli/commands/phisheye.py
@@ -25,13 +25,13 @@ def phisheye(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -42,7 +42,7 @@ def phisheye(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,
@@ -69,13 +69,13 @@ def phisheye_termlist(
     creds_file: str = typer.Option(
         "~/.dtapi",
         "-c",
-        "--cred_file",
+        "--credfile",
         help="Optional file with API username and API key, one per line.",
     ),
     rate_limit: bool = typer.Option(
         False,
         "-l",
-        "--rate_limit",
+        "--rate-limit",
         help="Rate limit API calls against the API based on per minute limits.",
     ),
     format: str = typer.Option(
@@ -86,7 +86,7 @@ def phisheye_termlist(
         callback=DTCLICommand.validate_format_input,
     ),
     out_file: typer.FileTextWrite = typer.Option(
-        sys.stdout, "-o", "--out_file", help="Output file (defaults to stdout)"
+        sys.stdout, "-o", "--out-file", help="Output file (defaults to stdout)"
     ),
     no_verify_ssl: bool = typer.Option(
         False,

--- a/domaintools/cli/main.py
+++ b/domaintools/cli/main.py
@@ -23,7 +23,7 @@ def main(
     ),
 ):
     """
-    Main callback of domaintools cli
+    Official Domaintools CLI
     """
     ...
 

--- a/domaintools/cli/utils.py
+++ b/domaintools/cli/utils.py
@@ -93,4 +93,21 @@ def get_file_extension(source: str) -> str:
     return ext
 
 
-__all__ = ["get_cli_helptext_by_name", "get_file_extension"]
+def remove_special_char_in_string(item: str, special_char: str) -> str:
+    """Removes the given `special char` in an string item.
+
+    Args:
+        item (str): The string to be formatted
+
+    Returns:
+        str: The formatted string.
+    """
+    cleaned_string = item.replace(special_char, "")
+    return cleaned_string
+
+
+__all__ = [
+    "get_cli_helptext_by_name",
+    "get_file_extension",
+    "remove_special_char_in_string",
+]

--- a/domaintools/cli/utils.py
+++ b/domaintools/cli/utils.py
@@ -7,25 +7,25 @@ def _iris_investigate_helptext():
     Returns back a list of domains based on the provided filters. The following filters are available beyond what is parameterized as kwargs: \n
     * --ip: Search for domains having this IP. \n
     * --email: Search for domains with this email in their data. \n
-    * --email_domain: Search for domains where the email address uses this domain.\n
-    * --nameserver_host: Search for domains with this nameserver.\n
-    * --nameserver_domain: Search for domains with a nameserver that has this domain.\n
-    * --nameserver_ip: Search for domains with a nameserver on this IP.\n
+    * --email-domain: Search for domains where the email address uses this domain.\n
+    * --nameserver-host: Search for domains with this nameserver.\n
+    * --nameserver-domain: Search for domains with a nameserver that has this domain.\n
+    * --nameserver-ip: Search for domains with a nameserver on this IP.\n
     * --registrar: Search for domains with this registrar.\n
     * --registrant: Search for domains with this registrant name.\n
-    * --registrant_org: Search for domains with this registrant organization.\n
-    * --mailserver_host: Search for domains with this mailserver.\n
-    * --mailserver_domain: Search for domains with a mailserver that has this domain.\n
-    * --mailserver_ip: Search for domains with a mailserver on this IP.\n
-    * --redirect_domain: Search for domains which redirect to this domain.\n
-    * --ssl_hash: Search for domains which have an SSL certificate with this hash.\n
-    * --ssl_subject: Search for domains which have an SSL certificate with this subject string.\n
-    * --ssl_email: Search for domains which have an SSL certificate with this email in it.\n
-    * --ssl_org: Search for domains which have an SSL certificate with this organization in it.\n
-    * --google_analytics: Search for domains which have this Google Analytics code.\n
+    * --registrant-org: Search for domains with this registrant organization.\n
+    * --mailserver-host: Search for domains with this mailserver.\n
+    * --mailserver-domain: Search for domains with a mailserver that has this domain.\n
+    * --mailserver-ip: Search for domains with a mailserver on this IP.\n
+    * --redirect-domain: Search for domains which redirect to this domain.\n
+    * --ssl-hash: Search for domains which have an SSL certificate with this hash.\n
+    * --ssl-subject: Search for domains which have an SSL certificate with this subject string.\n
+    * --ssl-email: Search for domains which have an SSL certificate with this email in it.\n
+    * --ssl-org: Search for domains which have an SSL certificate with this organization in it.\n
+    * --google-analytics: Search for domains which have this Google Analytics code.\n
     * --adsense: Search for domains which have this AdSense code.\n
     * --tld: Filter by TLD. Must be combined with another parameter.\n
-    * --search_hash: Use search hash from Iris to bring back domains.\n
+    * --search-hash: Use search hash from Iris to bring back domains.\n
     """
 
 


### PR DESCRIPTION
Changes:
 - Change optional parameters from underscore to use dash instead, make it backward compatible with the prev version.
 - Change iris_investigate kwargs parameter to use `-` instead of `_` to make it standard in other parameters.
 - Adjust the argument parser to make it compatible in API params. 
 - Add `-s` for short-hand command for `--source-file`.
 - Add a max limit of 100 domains when using the  `--source-file` parameter.
 - remove/strip colons on ssl hash input if colons happen to be present in the user-supplied certificate hash/fingerprint values.