### PR TITLE
IDEV-2546 Python wrapper used in any integration may cause a rate limit issue due to account rate limit checking

### DIFF
--- a/domaintools/api.py
+++ b/domaintools/api.py
@@ -34,6 +34,7 @@ from domaintools.filters import (
     filter_by_field,
     DTResultFilter,
 )
+from domaintools.exceptions import ServiceUnavailableException, ServiceException
 from domaintools.utils import validate_feeds_parameters
 
 
@@ -163,7 +164,12 @@ class API(object):
         if product != "account-information" and self.rate_limit and not self.limits_set and not self.limits:
             always_sign_api_key_previous_value = self.always_sign_api_key
             header_authentication_previous_value = self.header_authentication
-            self._rate_limit(product)
+            try:
+                self._rate_limit(product)
+            except (ServiceUnavailableException, ServiceException):
+                # If account_information fails (e.g. rate limited itself),
+                # skip client-side rate limiting and proceed with the original call.
+                self.limits_set = True
             # Reset always_sign_api_key and header_authentication to its original
             # User-set values as these might be affected when self.account_information() was executed
             self.always_sign_api_key = always_sign_api_key_previous_value

--- a/domaintools/base_results.py
+++ b/domaintools/base_results.py
@@ -140,7 +140,7 @@ class Results(MutableMapping, MutableSequence):
         wait_for = self._wait_time()
         if self.api.rate_limit and (wait_for is None or self.product == "account-information"):
             data = self._make_request()
-            if data.status_code == 503:  # pragma: no cover
+            if data.status_code == 503 and self.product != "account-information":  # pragma: no cover
                 sleeptime = 60
                 log.info(
                     "503 encountered for [%s] - sleeping [%s] seconds before retrying request.",


### PR DESCRIPTION
Update python wrapper with a patch that allows the wrapper to proceed with Iris Enrich call even if account_information returns a 503 error only (rate limit error).

See test results below, `main` branch will fail on account_info 503. But switching to `idev-2456-ignore-account-info-rate-limit` allows the test script to proceed with enrich call.
```
(venv) ➜  python_api git:(main) ✗ python3 westest-ignore-account-limit.py
Traceback (most recent call last):
  File "/Users/wagena/Documents/Projects/python_api/westest-ignore-account-limit.py", line 3, in <module>
    result = dt_api.iris_enrich('Amazon-Help-Desk.com')
  File "/Users/wagena/Documents/Projects/python_api/domaintools/api.py", line 634, in iris_enrich
    results = self._results(
  File "/Users/wagena/Documents/Projects/python_api/domaintools/api.py", line 166, in _results
    self._rate_limit(product)
  File "/Users/wagena/Documents/Projects/python_api/domaintools/api.py", line 151, in _rate_limit
    for product in self.account_information():
  File "/Users/wagena/Documents/Projects/python_api/domaintools/base_results.py", line 272, in __iter__
    return self._items().__iter__()
  File "/Users/wagena/Documents/Projects/python_api/domaintools/base_results.py", line 255, in _items
    response = self.response()
  File "/Users/wagena/Documents/Projects/python_api/domaintools/base_results.py", line 236, in response
    response = self.data()
  File "/Users/wagena/Documents/Projects/python_api/domaintools/base_results.py", line 163, in data
    self.setStatus(results.status_code, results)
  File "/Users/wagena/Documents/Projects/python_api/domaintools/base_results.py", line 226, in setStatus
    raise ServiceUnavailableException(code, reason)
domaintools.exceptions.ServiceUnavailableException: {'error': {'code': 503, 'message': 'You have exceeded the maximum number of requests per month allowed under your service level. (1/month)'}, 'resources': {'support': 'https://docs.domaintools.com'}}

(venv) ➜  python_api git:(main) ✗ git checkout idev-2456-ignore-account-info-rate-limit
Switched to branch 'idev-2456-ignore-account-info-rate-limit'
Your branch is up to date with 'origin/idev-2456-ignore-account-info-rate-limit'.

(venv) ➜  python_api git:(idev-2456-ignore-account-info-rate-limit) ✗ python3 westest-ignore-account-limit.py
{
    "response": {
        "limit_exceeded": false,
        "message": "Enjoy your data.",
        "results_count": 1,
        "results": [
            {
                "domain": "amazon-help-desk.com",
                ...
            }
        ],
        "missing_domains": []
    }
}
(venv) ➜  python_api git:(idev-2456-ignore-account-info-rate-limit) ✗ 
```