### PR TITLE
[IDEV-2584] RTTF Support for header authentication & CLI Improvements for download endpoint

### DIFF
--- a/PYTHON_SUPPORT.md
+++ b/PYTHON_SUPPORT.md
@@ -2,28 +2,20 @@
 
 ## Policy
 
-The DomainTools API library will support all versions of Python that are actively maintained by the Python 
+The DomainTools API library will support all versions of Python that are actively maintained by the Python
 Software Foundation. When a version of Python enters End of Life (EOL), the API library will also end support
-for that version of Python. 
+for that version of Python.
 
-When a version's End of Life date is reached, DomainTools will ensure that a release of the API library that 
+When a version's End of Life date is reached, DomainTools will ensure that a release of the API library that
 contains all changes up to that point in time is available. If a release already exists that has all
-changes at the point of a version's EOL date, no new one will be made. Any changes (features, bugfixes, etc) 
+changes at the point of a version's EOL date, no new one will be made. Any changes (features, bugfixes, etc)
 released after an EOL date will not be tested on the now-unsupported version.
 
-Versions of Python from other organizations (e.g. cython, pypy, jython) will not be actively supported. DomainTools 
-will not develop specifically for those versions of Python, but we welcome community assistance (such as pull 
+Versions of Python from other organizations (e.g. cython, pypy, jython) will not be actively supported. DomainTools
+will not develop specifically for those versions of Python, but we welcome community assistance (such as pull
 requests) to support them.
 
-### Python 2
 
-DomainTools API library support for Python 2.7 (and all Python 2) will end on November 30, 2020. 
+### Python >=3.9
 
-### Python 3.5
-
-DomainTools will continue to support Python 3.5 until November 30, 2020. 
-
-## Upcoming Timeline:
-
-- Support for Python 2.7 will end on Nov 30, 2020
-- Support for Python 3.5 will end on Nov 30, 2020
+DomainTools currently supports Python 3.9 and above.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Custom parameters aside from the common `GET` Request parameters:
     api = API(USERNAME, KEY)
     api.nod(endpoint="feed", **kwargs)
     ```
-- `header_authentication`: by default, we're using API Header Authentication. Set this False if you want to use API Key and Secret Authentication. Apparently, you can't use API Header Authentication for `download` endpoints so this will be defaulted to `False` even without explicitly setting it.
+- `header_authentication`: by default, all RTTF endpoints (both `feed` and `download`) use API Header Authentication, sending the API key via the `X-Api-Key` header. Set this to `False` to pass the API key as a query parameter instead.
     ```python
     api = API(USERNAME, KEY, header_authentication=False)
     api.nod(**kwargs)
@@ -275,7 +275,7 @@ Custom parameters aside from the common `GET` Request parameters:
     api.nod(output_format="csv", **kwargs)
     ```
 
-The Feed API standard access pattern is to periodically request the most recent feed data, as often as every 60 seconds. Specify the range of data you receive in one of two ways:
+The `feed` endpoint streams live NDJSON data. The standard access pattern is to poll as often as every 60 seconds. Specify the range of data you receive in one of two ways:
 
 1. With `sessionID`: Make a call and provide a new `sessionID` parameter of your choosing. The API will return the last hour of data by default.
     - Each subsequent call to the API using your `sessionID` will return all data since the last.
@@ -283,6 +283,16 @@ The Feed API standard access pattern is to periodically request the most recent 
 2. Or, specify the time range in one of two ways:
     - Either an `after=-60` query parameter, where (in this example) -60 indicates the previous 60 seconds.
     - Or `after` and `before` query parameters for a time range, with each parameter accepting an ISO-8601 UTC formatted timestamp (a UTC date and time of the format YYYY-MM-DDThh:mm:ssZ)
+
+The `download` endpoint returns a standard JSON response (not a stream) listing available S3 batch files. Time parameters (`sessionID`, `after`, `before`) are **not** required for download calls.
+
+```python
+api = API(USERNAME, KEY)
+result = api.nod(endpoint="download", limit=5)
+print(result["download_name"])
+for f in result["files"]:
+    print(f["name"], f["url"])
+```
 
 ### Feed parameters
 
@@ -325,11 +335,24 @@ The feed methods accept the following parameters, grouped by purpose. Availabili
 
 - `output_format`: `csv` or `jsonl` (default `jsonl`). Not available on the `domainrdap` feed. `csv` is not available for `download` endpoints.
 - `headers`: When `csv` output is used, adds a header row to the first line of the response.
-- `top`: Positive integer from `1` to `1,000,000,000` limiting the number of results in the response payload. 
+- `top`: Positive integer from `1` to `1,000,000,000` limiting the number of results in the response payload. Ignored for the `download` endpoint.
 
-## Handling iterative response from RTUF endpoints:
+#### Download-only parameters
 
-Since we may dealing with large feeds datasets, the python wrapper uses `generator` for efficient memory handling. Therefore, we need to iterate through the `generator` if we're accessing the partial results of the feeds data.
+These parameters are only accepted when `endpoint="download"`. They are ignored for the `feed` endpoint.
+
+- `limit`: Maximum number of files to return in the response.
+- `page`: Zero-indexed page of results to return. Available on `realtime_domain_risk`, `domainhotlist`, `iphotlist`, and `iprisk`.
+- `prefix`: Filter files by date prefix (e.g. `"2026-08-"`). Available on `realtime_domain_risk`, `domainhotlist`, `iphotlist`, and `iprisk`.
+
+```python
+api = API(USERNAME, KEY)
+api.iphotlist(endpoint="download", limit=10, page=0, prefix="2026-08-")
+```
+
+## Handling iterative response from RTTF endpoints:
+
+Since we may be dealing with large feeds datasets, the python wrapper uses `generator` for efficient memory handling. Therefore, we need to iterate through the `generator` if we're accessing the partial results of the feeds data.
 
 ### Single request because the requested data is within the maximum result:
 ```python

--- a/domaintools/api.py
+++ b/domaintools/api.py
@@ -199,6 +199,8 @@ class API(object):
             self.header_authentication = is_rttf_product
 
     def handle_api_key(self, is_rttf_product, path, parameters):
+        if self.header_authentication and not self.always_sign_api_key:
+            return
         if self.https and not self.always_sign_api_key:
             parameters["api_key"] = self.key
         else:
@@ -1204,11 +1206,16 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint)
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"newly-observed-domains-feed-({source.value})",
+                f"v1/{endpoint}/nod/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1247,11 +1254,16 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"newly-active-domains-feed-({source})",
+                f"v1/{endpoint}/nad/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1291,6 +1303,14 @@ class API(object):
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
 
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"domain-registration-data-access-protocol-feed-({source})",
+                f"v1/{endpoint}/domainrdap/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+            )
+
         return self._results(
             f"domain-registration-data-access-protocol-feed-({source})",
             f"v1/{endpoint}/domainrdap/",
@@ -1327,11 +1347,16 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"real-time-domain-discovery-feed-({source})",
+                f"v1/{endpoint}/domaindiscovery/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1370,11 +1395,16 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"newly-observed-hosts-feed-({source})",
+                f"v1/{endpoint}/noh/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1422,11 +1452,18 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"real-time-domain-risk-({source})",
+                f"v1/{endpoint}/domainrisk/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+                page=kwargs.get("page"),
+                prefix=kwargs.get("prefix"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1474,11 +1511,18 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"real-time-domain-hotlist-({source})",
+                f"v1/{endpoint}/domainhotlist/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+                page=kwargs.get("page"),
+                prefix=kwargs.get("prefix"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1544,11 +1588,18 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"real-time-ip-hotlist-({source})",
+                f"v1/{endpoint}/iphotlist/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+                page=kwargs.get("page"),
+                prefix=kwargs.get("prefix"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(
@@ -1614,11 +1665,18 @@ class API(object):
         validate_feeds_parameters(kwargs)
         endpoint = kwargs.pop("endpoint", Endpoint.FEED.value)
         source = ENDPOINT_TO_SOURCE_MAP.get(endpoint).value
-        if (
-            endpoint == Endpoint.DOWNLOAD.value
-            or kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value
-        ):
-            # headers param is allowed only in Feed API and CSV format
+
+        if endpoint == Endpoint.DOWNLOAD.value:
+            return self._results(
+                f"real-time-ip-risk-({source})",
+                f"v1/{endpoint}/iprisk/",
+                response_path=("response",),
+                limit=kwargs.get("limit"),
+                page=kwargs.get("page"),
+                prefix=kwargs.get("prefix"),
+            )
+
+        if kwargs.get("output_format", OutputFormat.JSONL.value) != OutputFormat.CSV.value:
             kwargs.pop("headers", None)
 
         return self._results(

--- a/domaintools/cli/api.py
+++ b/domaintools/cli/api.py
@@ -10,6 +10,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from domaintools.api import API
 from domaintools.constants import Endpoint, RTTF_PRODUCTS_LIST, OutputFormat
+from domaintools.results import FeedsResults
 from domaintools.cli.utils import get_file_extension
 from domaintools.exceptions import ServiceException
 from domaintools._version import current as version
@@ -114,8 +115,10 @@ class DTCLICommand:
     def _get_formatted_output(cls, cmd_name: str, response, out_format: str = "json"):
         if cmd_name in ("available_api_calls",):
             return "\n".join(response)
-        if response.product in RTTF_PRODUCTS_LIST:
-            pass  # do nothing
+        if isinstance(response, FeedsResults):
+            pass  # do nothing — streaming output handled in run()
+        elif out_format not in ("json", "xml", "html", "list"):
+            out_format = "json"  # download endpoint returns standard JSON
         return str(getattr(response, out_format) if out_format != "list" else response.as_list())
 
     @classmethod
@@ -225,12 +228,14 @@ class DTCLICommand:
                 params = params | kwargs
 
                 response = dt_api_func(**params)
+                if not isinstance(response, FeedsResults):
+                    response_format = "json"
                 progress.update(
                     task_id,
                     description=f"Preparing results with format of {response_format}...",
                 )
 
-                if name not in ("available_api_calls",) and not getattr(response, "product", None) in RTTF_PRODUCTS_LIST:
+                if name not in ("available_api_calls",) and not isinstance(response, FeedsResults):
                     response.data()
 
                 output = cls._get_formatted_output(
@@ -238,7 +243,7 @@ class DTCLICommand:
                 )
 
             if isinstance(out_file, _io.TextIOWrapper):
-                if name not in ("available_api_calls",) and response.product in RTTF_PRODUCTS_LIST:
+                if name not in ("available_api_calls",) and isinstance(response, FeedsResults):
                     for feeds in response.response():
                         print(feeds)
                 else:

--- a/domaintools/cli/commands/feeds.py
+++ b/domaintools/cli/commands/feeds.py
@@ -93,6 +93,11 @@ def feeds_nad(
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
 ):
     DTCLICommand.run(name=c.FEEDS_NAD, params=ctx.params)
 
@@ -182,6 +187,11 @@ def feeds_nod(
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
 ):
     DTCLICommand.run(name=c.FEEDS_NOD, params=ctx.params)
 
@@ -259,6 +269,11 @@ def feeds_domainrdap(
         None,
         "--top",
         help="Number of results to return in the response payload",
+    ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
     ),
 ):
     DTCLICommand.run(name=c.FEEDS_DOMAINRDAP, params=ctx.params)
@@ -349,6 +364,11 @@ def feeds_domaindiscovery(
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
 ):
     DTCLICommand.run(name=c.FEEDS_DOMAINDISCOVERY, params=ctx.params)
 
@@ -437,6 +457,11 @@ def feeds_noh(
         None,
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint",
+    ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
     ),
 ):
     DTCLICommand.run(name=c.FEEDS_NOH, params=ctx.params)
@@ -552,6 +577,21 @@ def feeds_domainhotlist(
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint. For risk feeds, results are sorted by all_threats_combined_percent (descending)",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
+    page: int = typer.Option(
+        None,
+        "--page",
+        help="Selects which page of results to return (0-indexed). Only applies to the download endpoint.",
+    ),
+    prefix: str = typer.Option(
+        None,
+        "--prefix",
+        help="Filters results by date using the file prefix. Only applies to the download endpoint.",
+    ),
 ):
     DTCLICommand.run(name=c.FEEDS_DOMAINHOTLIST, params=ctx.params)
 
@@ -665,6 +705,21 @@ def feeds_realtime_domain_risk(
         None,
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint. For risk feeds, results are sorted by all_threats_combined_percent (descending)",
+    ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
+    page: int = typer.Option(
+        None,
+        "--page",
+        help="Selects which page of results to return (0-indexed). Only applies to the download endpoint.",
+    ),
+    prefix: str = typer.Option(
+        None,
+        "--prefix",
+        help="Filters results by date using the file prefix. Only applies to the download endpoint.",
     ),
 ):
     DTCLICommand.run(name=c.FEEDS_REALTIME_DOMAIN_RISK, params=ctx.params)
@@ -824,6 +879,21 @@ def feeds_iphotlist(
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint. For risk feeds, results are sorted by all_threats_combined_percent (descending)",
     ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
+    page: int = typer.Option(
+        None,
+        "--page",
+        help="Selects which page of results to return (0-indexed). Only applies to the download endpoint.",
+    ),
+    prefix: str = typer.Option(
+        None,
+        "--prefix",
+        help="Filters results by date using the file prefix. Only applies to the download endpoint.",
+    ),
 ):
     DTCLICommand.run(name=c.FEEDS_IPHOTLIST, params=ctx.params)
 
@@ -981,6 +1051,21 @@ def feeds_iprisk(
         None,
         "--top",
         help="Number of results to return in the response payload. This is ignored in download endpoint. For risk feeds, results are sorted by all_threats_combined_percent (descending)",
+    ),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Limits the number of files returned in the response. Only applies to the download endpoint.",
+    ),
+    page: int = typer.Option(
+        None,
+        "--page",
+        help="Selects which page of results to return (0-indexed). Only applies to the download endpoint.",
+    ),
+    prefix: str = typer.Option(
+        None,
+        "--prefix",
+        help="Filters results by date using the file prefix. Only applies to the download endpoint.",
     ),
 ):
     DTCLICommand.run(name=c.FEEDS_IPRISK, params=ctx.params)

--- a/domaintools/utils.py
+++ b/domaintools/utils.py
@@ -175,13 +175,15 @@ def convert_str_to_dateobj(string_date: str, date_format: Optional[str] = "%Y-%m
 
 
 def validate_feeds_parameters(params):
-    sessionID = params.get("sessionID")
-    after = params.get("after")
-    before = params.get("before")
-    if not (sessionID or after or before):
-        raise ValueError("sessionID or after or before must be provided")
+    endpoint = params.get("endpoint")
+
+    if endpoint != Endpoint.DOWNLOAD.value:
+        sessionID = params.get("sessionID")
+        after = params.get("after")
+        before = params.get("before")
+        if not (sessionID or after or before):
+            raise ValueError("sessionID or after or before must be provided")
 
     format = params.get("output_format")
-    endpoint = params.get("endpoint")
     if endpoint == Endpoint.DOWNLOAD.value and format == OutputFormat.CSV.value:
         raise ValueError(f"{format} format is not available in {Endpoint.DOWNLOAD.value} API.")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -788,18 +788,22 @@ def test_verify_response_is_a_generator():
     assert isgenerator(results.response())
 
 
-@vcr.use_cassette
 def test_feeds_endpoint_should_non_header_auth_be_the_default():
-    results = feeds_api.domaindiscovery(after="-60", endpoint="download", top=5)
-    for response in results.response():
-        assert results.status == 200
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"response": {"download_name": "domaindiscovery", "files": []}}
 
-        response = response.strip()
-        assert response is not None
+    with patch("domaintools.base_results.Client") as mock_client:
+        mock_session = MagicMock()
+        mock_client.return_value.__enter__.return_value = mock_session
+        mock_session.get.return_value = mock_response
 
-        feed_result = json.loads(response)
-        assert "download_name" in feed_result["response"].keys()
-        assert "files" in feed_result["response"].keys()
+        feeds_api.always_sign_api_key = False
+        feeds_api.header_authentication = True
+        results = feeds_api.domaindiscovery(endpoint="download")
+
+        assert results["download_name"] == "domaindiscovery"
+        assert "files" in results
 
 
 @vcr.use_cassette
@@ -894,8 +898,71 @@ def test_ip_risk():
 @vcr.use_cassette
 def test_feeds_endpoint_should_raise_error_if_signed_api_key_is_used():
     feeds_api.always_sign_api_key = True
-    with pytest.raises(ValueError) as excinfo:
-        feeds_api.domaindiscovery(after="-60")
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            feeds_api.domaindiscovery(after="-60")
+        assert str(excinfo.value) == "Real Time Threat Feeds do not support signed API keys."
+    finally:
+        feeds_api.always_sign_api_key = False
+        feeds_api.header_authentication = True
 
-    assert str(excinfo.value) == "Real Time Threat Feeds do not support signed API keys."
+
+def test_rttf_api_key_not_leaked_as_query_param():
+    """api_key must not appear in query params when header_authentication is active (RTTF)."""
+    from domaintools.base_results import Results
+
+    mock_api = MagicMock()
+    mock_api.key = "secret_key"
+    mock_api.header_authentication = True
+
+    result = Results(
+        mock_api,
+        "newly-observed-domains-feed-(api)",
+        "https://api.domaintools.com",
+        api_username="testuser",
+        after="-60",
+    )
+    session_info = result._get_session_params_and_headers()
+
+    assert "api_key" not in session_info["parameters"]
+    assert session_info["headers"]["X-Api-Key"] == "secret_key"
+
+
+def test_rttf_api_key_not_leaked_full_flow():
+    """handle_api_key guard: api_key must not reach request params for RTTF feeds end-to-end."""
+    test_api = API("testuser", "secret_key", rate_limit=False)
+    result = test_api.nod(after="-60")
+    session_info = result._get_session_params_and_headers()
+
+    assert "api_key" not in session_info["parameters"]
+    assert session_info["headers"].get("X-Api-Key") == "secret_key"
+
+
+def test_standard_api_key_remains_in_query_params_without_header_auth():
+    """Standard (non-RTTF) endpoints keep api_key in query params when header_authentication is off."""
+    from domaintools.base_results import Results
+
+    mock_api = MagicMock()
+    mock_api.key = "secret_key"
+    mock_api.header_authentication = False
+
+    result = Results(
+        mock_api,
+        "whois",
+        "https://api.domaintools.com",
+        api_key="secret_key",
+        api_username="testuser",
+    )
+    session_info = result._get_session_params_and_headers()
+
+    assert "api_key" in session_info["parameters"]
+    assert "X-Api-Key" not in session_info["headers"]
+
+
+def test_feeds_download_endpoint_does_not_require_time_params():
+    """endpoint='download' must not raise when no sessionID/after/before are given."""
+    feeds_api.always_sign_api_key = False
+    feeds_api.header_authentication = True
+    result = feeds_api.nod(endpoint="download")
+    assert result is not None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,15 +119,23 @@ def test_get_pivots():
     assert pivots == [["IP ADDRESS", ("199.30.228.112", 4)], ["IP ASN", (17318, 111)], ["IP ISP", ("DomainTools LLC", 222)]]
 
 
-def test_validate_feeds_parameters_should_raise_error_if_no_required_params(test_feeds_params):
-    test_feeds_params.pop("sessionID", None)
-    test_feeds_params.pop("after", None)
-    test_feeds_params.pop("before", None)
-
+def test_validate_feeds_parameters_should_raise_error_if_no_required_params():
     with pytest.raises(ValueError) as excinfo:
-        utils.validate_feeds_parameters(test_feeds_params)
+        utils.validate_feeds_parameters({"endpoint": "feed"})
 
     assert str(excinfo.value) == "sessionID or after or before must be provided"
+
+
+def test_validate_feeds_parameters_download_does_not_require_time_params():
+    # download endpoint should not require sessionID / after / before
+    utils.validate_feeds_parameters({"endpoint": "download"})
+
+
+def test_validate_feeds_parameters_download_still_rejects_csv_format():
+    with pytest.raises(ValueError) as excinfo:
+        utils.validate_feeds_parameters({"endpoint": "download", "output_format": "csv"})
+
+    assert str(excinfo.value) == "csv format is not available in download API."
 
 
 def test_validate_feeds_parameters_should_raise_error_if_asked_csv_format_for_download_api(test_feeds_params):


### PR DESCRIPTION
Fix: RTTF API key no longer leaks as a plain query param.** When `header_authentication` is active (the default for all Real-Time Threat Feed endpoints), `api_key` is now sent exclusively via the `X-Api-Key` header and is removed from query parameters.

- **Fix: `endpoint=download` no longer requires time params.** `validate_feeds_parameters` was erroneously requiring `sessionID`/`after`/`before` for download calls. Download endpoints don't use a session window, so the check is now skipped when `endpoint=download`.

- **Fix: download endpoint now returns correct result type and response shape.** All 9 feed methods (`nod`, `nad`, `noh`, `domainrdap`, `domaindiscovery`, `realtime_domain_risk`, `domainhotlist`, `iphotlist`, `iprisk`) previously returned a streaming `FeedsResults` for the download path. They now return a standard `Results` with `response_path=("response",)`, matching the actual JSON shape of the download API.

- **Fix: feed-specific params no longer leak into download requests.** Download path calls now only forward `limit`/`page`/`prefix`; stream-only params (`sessionID`, `after`, `domain`, etc.) are no longer included.

- **CLI: added `--limit` to all 9 feed commands.** Previously missing from the CLI surface; only applies to `endpoint=download`.

- **Fix: CLI download output now renders as JSON.** The download endpoint response was previously printed as a Python dict repr (`{'key': ...}`) because the formatter treated it as a streaming feed. It now correctly formats as JSON.

- **Updated `PYTHON_SUPPORT.md`** to reflect the Python >=3.9 requirement.

- **Updated `README.md` Feeds section:**
  - Corrected false claim that `header_authentication` defaults to `False` for download endpoints — it is `True` for all RTTF endpoints.
  - Added download endpoint usage example and note that time params are not required.
  - Added `limit`, `page`, `prefix` parameter documentation under a new "Download-only parameters" subsection.
  - Added note that `top` is ignored for the download endpoint.
  - Fixed typos: "RTUF" → "RTTF", "we may dealing" → "we may be dealing".